### PR TITLE
add arrows to illustrate strand for primary frags

### DIFF
--- a/frontend/src/components/trackVis/GenomeAlignTrack.tsx
+++ b/frontend/src/components/trackVis/GenomeAlignTrack.tsx
@@ -207,7 +207,7 @@ class GenomeAlignTrackWithoutOptions extends React.PureComponent<PropsFromTrackC
           y={y}
           height={RECT_HEIGHT}
           opacity={0.75}
-          isToRight={!placement.record.getIsReverseStrandQuery()}
+          isToRight={!(isQuery && placement.record.getIsReverseStrandQuery())}
           color="white"
           separation={baseWidth}
         />
@@ -224,7 +224,7 @@ class GenomeAlignTrackWithoutOptions extends React.PureComponent<PropsFromTrackC
             strokeDasharray={baseWidth / 2}
           />
           {rects}
-          {isQuery && arrows}
+          {arrows}
           {letters}
         </React.Fragment>
       );


### PR DESCRIPTION
Add strand information to the primary sequences in the genome-align track. Based on Ting's suggestion.