### PR TITLE
fix tooltop seq bug

### DIFF
--- a/frontend/src/components/trackVis/commonComponents/AlignmentCoordinates.js
+++ b/frontend/src/components/trackVis/commonComponents/AlignmentCoordinates.js
@@ -45,13 +45,13 @@ class AlignmentSequence extends React.Component {
             const cusorTargetSeqLeft = record.targetSeq.substr(
                 start + relativeDisplayStart, relativeHighlightStart - relativeDisplayStart).toUpperCase();
             const cusorTargetSeqMid = record.targetSeq.substr(start + relativeHighlightStart, highlightLength).toUpperCase();
-            const cusorTargetSeqRight = record.targetSeq.substr(start + relativeHighlightEnd + 1, relativeDisplayEnd - relativeHighlightEnd).toUpperCase();
+            const cusorTargetSeqRight = record.targetSeq.substr(start + relativeHighlightStart + highlightLength, relativeDisplayEnd - relativeHighlightEnd).toUpperCase();
 
             const cusorQuerySeqLeft = record.querySeq.substr(
                 start + relativeDisplayStart, relativeHighlightStart - relativeDisplayStart).toUpperCase();
             const cusorQuerySeqMid = record.querySeq.substr(start + relativeHighlightStart, highlightLength).toUpperCase();
             const cusorQuerySeqRight = record.querySeq.substr(
-                start + relativeHighlightEnd + 1, relativeDisplayEnd - relativeHighlightEnd).toUpperCase();
+                start + relativeHighlightStart + highlightLength, relativeDisplayEnd - relativeHighlightEnd).toUpperCase();
 
             const targetBaseLookup = makeBaseNumberLookup(visiblePart.getTargetSequence(),visiblePart.relativeStart);
             const targetStart = record.locus.start + targetBaseLookup[relativeDisplayStart];


### PR DESCRIPTION
There is a bug displaying the sequence in the alignment tooltip:
![image](https://user-images.githubusercontent.com/2028370/224166989-59f50166-2fbd-4c12-a563-001a8fe97370.png)
It should be fix by the pull request.
