### PR TITLE
Fix Chrome 112 Navbar

### DIFF
--- a/frontend/src/components/Nav.css
+++ b/frontend/src/components/Nav.css
@@ -16,12 +16,12 @@ followint this example https://codepen.io/EightArmsHQ/pen/mvqJwg?editors=1100
     display: flex;
     flex-grow: 1;
     flex-wrap: wrap;
-    .element {
+    /* .element {
         min-width: 33%;
         max-width: 100%;
         flex-grow: 1;
         flex-basis: calc(var(--multiplier) * 999);
-    }
+    } */
 }
 
 .element {


### PR DESCRIPTION
Update CSS in Nav.css to fix Navbar from nested CSS changes in Chrome 112.

https://developer.chrome.com/blog/new-in-chrome-112/#nesting-rules